### PR TITLE
feat: route installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,38 +7,40 @@
 <!-- START PACKAGES -->
 
 **Packages**  
-[@truffle/ui@`0.1.12`](./ui) - Unified UI library (WIP)  
-[@truffle/context@`1.0.0`](./context) - Framework-agnostic context  
-[@truffle/youtube-js@`0.5.9`](./youtube-js) - Truffle fork of [Youtube.js](https://github.com/LuanRT/YouTube.js)  
-[@truffle/config@`1.0.0`](./config) - Env/API config  
-[@truffle/utils@`0.0.35`](./utils) - Browser & Node utilities  
-[@truffle/state@`0.0.12`](./state) - Signals coupled with Legend state for React  
+[@truffle/router@`1.0.0`](./router) - Framework-agnostic fs router  
+[@truffle/events@`0.0.1`](./events) - Utilities for handling webhooks from Truffle  
 [@truffle/distribute@`2.0.20`](./distribute) - Wrappers to create web components from various frameworks  
+[@truffle/global-context@`1.0.0`](./global-context) - Truffle Global Context to share info between packages  
+[@truffle/config@`1.0.0`](./config) - Env/API config  
 [@truffle/third-party-oauth@`2.0.22`](./third-party-oauth) - Login and other auth utilities  
 [@truffle/api@`0.2.27`](./api) - Hooks and functions for interacting with Truffle's backend  
-[@truffle/global-context@`1.0.0`](./global-context) - Truffle Global Context to share info between packages  
-[@truffle/events@`0.0.1`](./events) - Utilities for handling webhooks from Truffle  
-[@truffle/router@`1.0.0`](./router) - Framework-agnostic fs router
+[@truffle/utils@`0.0.35`](./utils) - Browser & Node utilities  
+[@truffle/ui@`0.1.12`](./ui) - Unified UI library (WIP)  
+[@truffle/context@`1.0.0`](./context) - Framework-agnostic context  
+[@truffle/state@`0.0.12`](./state) - Signals coupled with Legend state for React  
+[@truffle/youtube-js@`0.5.9`](./youtube-js) - Truffle fork of [Youtube.js](https://github.com/LuanRT/YouTube.js)  
+[@truffle/route-installer@`0.5.7`](./route-installer) - Provides an action that allows packages to add their routes into other packages.  
+[@truffle/functions@`0.0.4`](./functions) - Utilities for creating Truffle Edge Functions
 
 **Examples**  
-[@truffle/spotify-integration@`3.0.1`](./examples/spotify-integration) - Spotify Now Playing widget  
-[@truffle/create-react-project@`0.5.8`](./examples/create-react-project) - Truffle project React template  
-[@truffle/mashing-minigame@`0.2.12`](./examples/mashing-minigame) - Round-based minigame example  
 [@truffle/mutation-observer@`0.4.2`](./examples/mutation-observer) - Mutation Observer example  
-[@truffle/chants@`0.0.5`](./examples/chants) - Chants  
+[@truffle/mashing-minigame@`0.2.12`](./examples/mashing-minigame) - Round-based minigame example  
+[@truffle/spotify-integration@`3.0.1`](./examples/spotify-integration) - Spotify Now Playing widget  
 [@truffle/events-demo-backend@`0.0.12`](./examples/events-demo-backend) - [Events](../../events) demo  
+[@truffle/create-react-project@`0.5.8`](./examples/create-react-project) - Truffle project React template  
 [@dev/chessmaster@`0.6.3`](./examples/chessmaster) - A package to facilitate a streamer vs chat chess game using https://lichess.org.  
-[@truffle/demo-discord-bot@`0.0.1`](./examples/discord-bot-demo) - Discord bot using Truffle API  
 [@truffle/viewer-polls@`0.2.4`](./examples/viewer-polls) - Stream Polls  
-[@truffle/song-suggestions@`0.0.24`](./examples/song-suggestions) - Song Suggestions Suite
+[@truffle/demo-discord-bot@`0.0.1`](./examples/discord-bot-demo) - Discord bot using Truffle API  
+[@truffle/song-suggestions@`0.0.24`](./examples/song-suggestions) - Song Suggestions Suite  
+[@truffle/chants@`0.0.5`](./examples/chants) - Chants
 
 **Stream Projects**  
-[@truffle/chat@`0.0.16`](./stream-projects/chat) - Chat client for 3rd party chats  
+[@truffle/notifications@`0.1.4`](./stream-projects/notifications) - Send notifications to your users when you go live.  
 [@truffle/do-something@`0.1.4`](./stream-projects/do-something) - Let your audience control you through collectibles!  
 [@truffle/raid@`1.0.4`](./stream-projects/raid) - Stream Raids  
 [@truffle/better-chat@`0.0.13`](./stream-projects/better-chat) - Youtube chat mutation observer  
-[@truffle/notifications@`0.1.2`](./stream-projects/notifications) - Send notifications to your users when you go live.  
-[@truffle/chat-theme@`0.0.2`](./stream-projects/chat-theme) - Theme for chat
+[@truffle/chat@`0.0.16`](./stream-projects/chat) - Chat client for 3rd party chats  
+[@truffle/chat-theme@`0.0.3`](./stream-projects/chat-theme) - Theme for chat
 
 <!-- END PACKAGES -->
 

--- a/route-installer/.gitignore
+++ b/route-installer/.gitignore
@@ -1,0 +1,1 @@
+truffle.secret.*

--- a/route-installer/README.md
+++ b/route-installer/README.md
@@ -1,0 +1,3 @@
+# truffle-default-site
+
+Requires Node >= 18

--- a/route-installer/deno.json
+++ b/route-installer/deno.json
@@ -1,0 +1,18 @@
+{
+  "tasks": {
+    "dev": "we'll add as soon as deno is ready for us :)"
+  },
+  "compilerOptions": {
+    "jsx": "react-jsxdev",
+    "jsxImportSource": "react",
+    "lib": [
+      "deno.ns",
+      "dom"
+    ]
+  },
+  "fmt": {
+    "options": {
+      "lineWidth": 100
+    }
+  }
+}

--- a/route-installer/deno.lock
+++ b/route-installer/deno.lock
@@ -1,0 +1,24 @@
+{
+  "version": "2",
+  "remote": {
+    "https://deno.land/std@0.167.0/async/abortable.ts": "80b2ac399f142cc528f95a037a7d0e653296352d95c681e284533765961de409",
+    "https://deno.land/std@0.167.0/async/deadline.ts": "2c2deb53c7c28ca1dda7a3ad81e70508b1ebc25db52559de6b8636c9278fd41f",
+    "https://deno.land/std@0.167.0/async/debounce.ts": "60301ffb37e730cd2d6f9dadfd0ecb2a38857681bd7aaf6b0a106b06e5210a98",
+    "https://deno.land/std@0.167.0/async/deferred.ts": "77d3f84255c3627f1cc88699d8472b664d7635990d5358c4351623e098e917d6",
+    "https://deno.land/std@0.167.0/async/delay.ts": "5a9bfba8de38840308a7a33786a0155a7f6c1f7a859558ddcec5fe06e16daf57",
+    "https://deno.land/std@0.167.0/async/mod.ts": "7809ad4bb223e40f5fdc043e5c7ca04e0e25eed35c32c3c32e28697c553fa6d9",
+    "https://deno.land/std@0.167.0/async/mux_async_iterator.ts": "770a0ff26c59f8bbbda6b703a2235f04e379f73238e8d66a087edc68c2a2c35f",
+    "https://deno.land/std@0.167.0/async/pool.ts": "6854d8cd675a74c73391c82005cbbe4cc58183bddcd1fbbd7c2bcda42b61cf69",
+    "https://deno.land/std@0.167.0/async/retry.ts": "e8e5173623915bbc0ddc537698fa418cf875456c347eda1ed453528645b42e67",
+    "https://deno.land/std@0.167.0/async/tee.ts": "3a47cc4e9a940904fd4341f0224907e199121c80b831faa5ec2b054c6d2eff5e",
+    "https://deno.land/std@0.167.0/http/server.ts": "e99c1bee8a3f6571ee4cdeb2966efad465b8f6fe62bec1bdb59c1f007cc4d155",
+    "https://tfl.dev/@truffle/functions@0.0.3/mod.ts": "d41d38c96ef1ec09a6c25e50bde7032bb3824279a6fe9b5f370fede836f0ed93",
+    "https://tfl.dev/@truffle/functions@0.0.3/utils/graphql-client.ts": "a9058e49649169b9e29c3f9b64cb7289f1ef239d94359ed4df9f677c2f2f0d9f",
+    "https://tfl.dev/@truffle/functions@0.0.3/utils/make-resp.ts": "6b913f32a33bf1c64d89d5f23e401da8bc9cf9d2a8f77c3125251de9daa9bf51",
+    "https://tfl.dev/@truffle/functions@0.0.3/utils/serve.ts": "0b99cd8db41d666978f23b804d7864375752314059911083701a50838fd39644",
+    "https://tfl.dev/@truffle/functions@0.0.4/mod.ts": "d41d38c96ef1ec09a6c25e50bde7032bb3824279a6fe9b5f370fede836f0ed93",
+    "https://tfl.dev/@truffle/functions@0.0.4/utils/graphql-client.ts": "a9058e49649169b9e29c3f9b64cb7289f1ef239d94359ed4df9f677c2f2f0d9f",
+    "https://tfl.dev/@truffle/functions@0.0.4/utils/make-resp.ts": "6b913f32a33bf1c64d89d5f23e401da8bc9cf9d2a8f77c3125251de9daa9bf51",
+    "https://tfl.dev/@truffle/functions@0.0.4/utils/serve.ts": "4a32644642e829cde175e5f8c89efc62261724ea3864578a2ff7dcdd8de0caff"
+  }
+}

--- a/route-installer/deps.ts
+++ b/route-installer/deps.ts
@@ -1,0 +1,6 @@
+export {
+  makeResp,
+  serveTruffleEdgeFunction,
+  MyceliumClient,
+  gql,
+} from "https://tfl.dev/@truffle/functions@~0.0.4/mod.ts";

--- a/route-installer/functions/install-routes.ts
+++ b/route-installer/functions/install-routes.ts
@@ -1,0 +1,59 @@
+import { makeResp, serveTruffleEdgeFunction } from "../deps.ts";
+import { getModulesByPackageVersionId } from "./util/modules.ts";
+import { getPackageByPath } from "./util/package.ts";
+import { saveRoute } from "./util/route.ts";
+
+interface InstallRouteRuntimeData {
+  packagePath: string;
+}
+
+serveTruffleEdgeFunction<InstallRouteRuntimeData>(
+  async ({ myceliumClient, runtimeData }) => {
+    // get the package version id
+    const packagePath = runtimeData?.packagePath;
+    if (!packagePath) {
+      return makeResp(400, {
+        error: true,
+        message: "Please specify packagePath in the runtimeData.",
+      });
+    }
+    const pkg = await getPackageByPath(packagePath, myceliumClient);
+    if (!pkg) {
+      return makeResp(404, {
+        error: true,
+        message: "Could not find package with specified slug.",
+      });
+    }
+
+    const packageVersionId = pkg.latestPackageVersionId;
+
+    // query for the modules
+    const modules = await getModulesByPackageVersionId(
+      packageVersionId,
+      myceliumClient
+    );
+
+    // console.log({ modules });
+
+    // for each module, check if it has a ROUTE_INSTALL_PATH export;
+    // if it does, upsert a route
+    for (const module of modules) {
+      const filename = module.filename;
+      const filenameParts = filename.split("/");
+      const isLayoutFile = filename.indexOf("layout.tsx") !== -1;
+      if (filenameParts[1] === "routes" && !isLayoutFile) {
+        console.log("saving route", module);
+        await saveRoute({
+          filenameParts: filenameParts.slice(1),
+          module,
+          otherModules: modules,
+          // FIXME this is the wrong packageVersionId... it needs to be the packageVersionId of the package that we're installing into
+          packageVersionId,
+          myceliumClient,
+        });
+      }
+    }
+
+    return makeResp(200, { message: "success" });
+  }
+);

--- a/route-installer/functions/util/graphql-client.ts
+++ b/route-installer/functions/util/graphql-client.ts
@@ -1,0 +1,31 @@
+const MYCELIUM_API_URL = "https://mycelium.truffle.vip/graphql";
+
+interface MyceliumOptions {
+  accessToken: string;
+  orgId: string;
+}
+
+export interface GQLResponse<T = unknown> {
+  data: T;
+  errors: unknown[];
+}
+
+export function graphqlReq(
+  query: string,
+  variables: Record<string, unknown>,
+  options: MyceliumOptions
+) {
+  return fetch(MYCELIUM_API_URL, {
+    method: "POST",
+    body: JSON.stringify({ query, variables }),
+    headers: {
+      "Content-Type": "application/json",
+      "x-org-id": options.orgId,
+      "x-access-token": options.accessToken,
+    },
+  });
+}
+
+export function gql(strings: TemplateStringsArray, ..._values: string[]) {
+  return strings.join();
+}

--- a/route-installer/functions/util/make-resp.ts
+++ b/route-installer/functions/util/make-resp.ts
@@ -1,0 +1,8 @@
+export function makeResp(statusCode: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: statusCode,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}

--- a/route-installer/functions/util/modules.ts
+++ b/route-installer/functions/util/modules.ts
@@ -1,0 +1,49 @@
+import { MyceliumClient, gql } from "../../deps.ts";
+
+export interface Module {
+  id: string;
+  filename: string;
+  exports: {
+    name: string;
+    type: string;
+    componentRel: {
+      id: string;
+    };
+  }[];
+}
+
+interface ModuleConnection {
+  nodes: Module[];
+}
+
+const MODULE_CONNECTION_QUERY = gql`
+  query ($packageVersionId: ID!) {
+    moduleConnection(input: { packageVersionId: $packageVersionId }) {
+      nodes {
+        id
+        filename
+        exports {
+          name
+          type
+          componentRel {
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+export async function getModulesByPackageVersionId(
+  packageVersionId: string,
+  myceliumClient: MyceliumClient
+) {
+  return (
+    await myceliumClient.query<{ moduleConnection: ModuleConnection }>(
+      MODULE_CONNECTION_QUERY,
+      {
+        packageVersionId,
+      }
+    )
+  )?.moduleConnection?.nodes;
+}

--- a/route-installer/functions/util/package.ts
+++ b/route-installer/functions/util/package.ts
@@ -1,0 +1,24 @@
+import { MyceliumClient, gql } from "../../deps.ts";
+
+interface Package {
+  id: string;
+  latestPackageVersionId: string;
+}
+
+const PACKAGE_QUERY = gql`
+  query ($path: String!) {
+    package(input: { path: $path }) {
+      id
+      latestPackageVersionId
+    }
+  }
+`;
+
+export async function getPackageByPath(
+  path: string,
+  myceliumClient: MyceliumClient
+) {
+  return (
+    await myceliumClient.query<{ package: Package }>(PACKAGE_QUERY, { path })
+  )?.package;
+}

--- a/route-installer/functions/util/route.ts
+++ b/route-installer/functions/util/route.ts
@@ -1,0 +1,139 @@
+import { MyceliumClient } from "../../deps.ts";
+import { Module } from "./modules.ts";
+
+export interface RouteUpsertInput {
+  packageVersionId?: string;
+  pathWithVariables?: string;
+  parentId?: string;
+  componentId?: string;
+  type?: "layout" | "page" | "empty";
+  data?: Record<string, unknown>;
+  myceliumClient: MyceliumClient;
+}
+
+interface RouteUpsertResponse {
+  routeUpsert: {
+    route: {
+      id: string;
+    };
+  };
+}
+
+let id = 0;
+export async function routeUpsert({
+  packageVersionId,
+  pathWithVariables,
+  parentId,
+  componentId,
+  type,
+  data,
+  myceliumClient,
+}: RouteUpsertInput) {
+  const query = `
+    mutation RouteUpsert($input: RouteUpsertInput!) {
+      routeUpsert(input: $input) {
+        route { id }
+      }
+    }  
+  `;
+  const variables = {
+    input: {
+      pathWithVariables,
+      packageVersionId,
+      parentId,
+      componentId,
+      data,
+      type,
+    },
+  };
+
+  console.log("upserting", { pathWithVariables, parentId, componentId, type });
+  return { id: String(id++) };
+
+  const response = await myceliumClient.query<RouteUpsertResponse>(
+    query,
+    variables
+  );
+  return response?.routeUpsert?.route;
+}
+
+export async function saveRoute({
+  filenameParts,
+  module,
+  otherModules,
+  packageVersionId,
+  myceliumClient,
+}: {
+  filenameParts: string[];
+  module: Module;
+  otherModules: Module[];
+  packageVersionId: string;
+  myceliumClient: MyceliumClient;
+}) {
+  const defaultExportComponentId = module.exports.find(
+    ({ type }) => type === "default"
+  )?.componentRel?.id;
+
+  const filenamePath = `/${filenameParts
+    .slice(1, filenameParts.length - 1)
+    .join("/")}`;
+  const dbPath = filenamePath
+    // nextjs style catch alls `[...slug]`. dir names can't be * on windows
+    // TODO: support the difference between [[...slug]] and [...slug]
+    // https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes)
+    .replace(/\[?\[\.\.\.(.*?)\]\]?/g, "*")
+    // /abc/[param] -> /abc/:param
+    .replace(/\[(.*?)\]/g, ":$1");
+  const pathParts = dbPath.split("/");
+  const fileParts = filenamePath.split("/");
+  const paths = pathParts.map(
+    (_, i) => `${pathParts.slice(0, i + 1).join("/")}`
+  );
+  const filenames = fileParts.map(
+    (_, i) => `${fileParts.slice(0, i + 1).join("/")}`
+  );
+  // make sure there's a top level route
+  let prevRoute = await routeUpsert({
+    packageVersionId,
+    pathWithVariables: "",
+    type: "empty",
+    myceliumClient,
+  });
+  // create a top level router and another router for any folders w/ layout.tsx
+  for await (const [i, path] of paths.entries()) {
+    if (path === "/") {
+      break;
+    } // we already upsert one for path = ''
+
+    // FIXME: support .ts|.jsx|.js too
+    const layoutFilename = `/routes${filenames[i]}/layout.tsx`;
+    const layoutModule = otherModules.find(
+      ({ filename }) => filename === layoutFilename
+    );
+
+    let layoutDefaultExportComponentId = "";
+    if (layoutModule) {
+      layoutDefaultExportComponentId =
+        layoutModule.exports.find(({ type }) => type === "default")
+          ?.componentRel?.id ?? "";
+    }
+
+    prevRoute = await routeUpsert({
+      packageVersionId,
+      parentId: prevRoute?.id,
+      pathWithVariables: path,
+      componentId: layoutDefaultExportComponentId,
+      type: layoutModule ? "layout" : "empty",
+      myceliumClient,
+    });
+  }
+
+  await routeUpsert({
+    packageVersionId,
+    parentId: prevRoute?.id,
+    pathWithVariables: pathParts.join("/"),
+    componentId: defaultExportComponentId,
+    type: "page",
+    myceliumClient,
+  });
+}

--- a/route-installer/package.json
+++ b/route-installer/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "truffle-cli": "file:../../../truffle-cli"
+  }
+}

--- a/route-installer/truffle.config.mjs
+++ b/route-installer/truffle.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  name: "@truffle/route-installer",
+  version: "0.5.7",
+  apiUrl: "https://mycelium.truffle.vip/graphql",
+  requestedPermissions: [],
+  installActionRel: {},
+}

--- a/route-installer/truffle.config.mjs
+++ b/route-installer/truffle.config.mjs
@@ -2,6 +2,8 @@ export default {
   name: "@truffle/route-installer",
   version: "0.5.7",
   apiUrl: "https://mycelium.truffle.vip/graphql",
+  description:
+    "Provides an action that allows packages to add their routes into other packages.",
   requestedPermissions: [],
   installActionRel: {},
-}
+};


### PR DESCRIPTION
This package enables packages to install their routes into other packages. It has a function and an action that can be invoked during the installation of a package. A common use case for this is if a package has a special admin interface to configure it. It can add itself to the creator's site. To use the function, call it with the following payload: 
```
{
    "runtimeData": {
        "packagePath": "PATH OF PACKAGE WITH ROUTES TO INSTALL"
    }
}
```

Problems left to solve:
- Somehow we need to determine what the package version id is for the package we're installing into. See https://github.com/trufflehq/truffle-packages/pull/71/files#diff-fd307a40fbacae320f112c47e318ad588fa318e1ac495bdccfcf156accd1b231R50
- If the parent package is redeployed (often will be the creator's site), the routes installed by this package won't be in the new version, so someone/something will have to rerun this function every time a creator redeploys their site.