### PR TITLE
feat: initial handshake when connecting

### DIFF
--- a/npm/transframe/src/interfaces/background-script/consumer.ts
+++ b/npm/transframe/src/interfaces/background-script/consumer.ts
@@ -48,13 +48,13 @@ export class BackgroundScriptConsumerInterface
     }
   }
 
-  public close() {
+  public disconnect() {
     this._port?.onMessage.removeListener(this._messageHandlerWrapper);
     this._port?.disconnect();
     this._isConnected = false;
   }
 
-  public sendMessage(message: RPCRequest) {
+  public sendMessage(message: unknown) {
     this._port?.postMessage(message);
   }
 

--- a/npm/transframe/src/interfaces/iframe/consumer.ts
+++ b/npm/transframe/src/interfaces/iframe/consumer.ts
@@ -31,12 +31,12 @@ export class IframeConsumerInterface implements TransframeConsumerInterface {
     this._isConnected = true;
   }
 
-  public close() {
+  public disconnect() {
     window.removeEventListener("message", this._messageHandlerWrapper);
     this._isConnected = false;
   }
 
-  public sendMessage(message: RPCRequest) {
+  public sendMessage(message: unknown) {
 
     // default to using the top most window as the provider unless the user specified otherwise
     let providerWindow: Window | null;

--- a/npm/transframe/src/interfaces/types.ts
+++ b/npm/transframe/src/interfaces/types.ts
@@ -1,4 +1,4 @@
-import { RPCReplyFunction, RPCRequest } from "../rpc/types";
+import { RPCReplyFunction } from "../rpc/types";
 import { Context } from "../types";
 
 export interface TransframeProviderInterface<Frame, ContextType> {
@@ -14,7 +14,7 @@ export interface TransframeProviderInterface<Frame, ContextType> {
 export interface TransframeConsumerInterface {
   isConnected: boolean;
   connect: () => void;
-  close: () => void;
-  sendMessage: (message: RPCRequest) => void;
+  disconnect: () => void;
+  sendMessage: (message: unknown) => void;
   onMessage(callback: (message: unknown) => void): void;
 }

--- a/npm/transframe/src/rpc/types.ts
+++ b/npm/transframe/src/rpc/types.ts
@@ -2,6 +2,8 @@ export enum RPCMessageType {
   RPC_REQUEST = 'rpc-request',
   RPC_RESPONSE = 'rpc-response',
   RPC_CALLBACK_CALL = 'rpc-callback-call',
+  RPC_CONNECT_REQUEST = 'rpc-connect-request',
+  RPC_CONNECT_RESPONSE = 'rpc-connect-response',
 }
 
 export interface RPCMessage {
@@ -84,6 +86,25 @@ export interface RPCCallbackCall extends RPCMessage {
   payload: unknown;
 }
 
+export interface RPCConnectRequest extends RPCMessage {
+  /**
+   * The type of the message
+   */
+  type: RPCMessageType.RPC_CONNECT_REQUEST;
+}
+
+export interface RPCConnectResponse extends RPCMessage {
+  /**
+   * The type of the message
+   */
+  type: RPCMessageType.RPC_CONNECT_RESPONSE;
+
+  /**
+   * The list of methods that are available
+   */
+  methods: string[];
+}
+
 export interface RPCCallbackPlaceholderParam {
   /**
    * Magic property to identify this as a transframe RPC callback placeholder
@@ -96,4 +117,4 @@ export interface RPCCallbackPlaceholderParam {
   callbackId: string;
 }
 
-export type RPCReplyFunction = (message: RPCResponse | RPCCallbackCall) => void;
+export type RPCReplyFunction = (message: RPCResponse | RPCCallbackCall | RPCConnectResponse) => void;

--- a/npm/transframe/src/rpc/util.ts
+++ b/npm/transframe/src/rpc/util.ts
@@ -1,5 +1,32 @@
 import { generateId } from "../util";
-import { RPCCallbackCall, RPCCallbackPlaceholderParam, RPCMessage, RPCMessageType, RPCRequest, RPCResponse } from "./types";
+import { RPCCallbackCall, RPCCallbackPlaceholderParam, RPCConnectRequest, RPCConnectResponse, RPCMessage, RPCMessageType, RPCRequest, RPCResponse } from "./types";
+
+export function createRpcConnectRequest({
+  namespace,
+}: {
+  namespace?: string;
+}): RPCConnectRequest{
+  return {
+    _transframe: true,
+    type: RPCMessageType.RPC_CONNECT_REQUEST,
+    namespace,
+  }
+}
+
+export function createRpcConnectResponse({
+  namespace,
+  methods
+}: {
+  namespace?: string;
+  methods: string[];
+}): RPCConnectResponse {
+  return {
+    _transframe: true,
+    type: RPCMessageType.RPC_CONNECT_RESPONSE,
+    namespace,
+    methods,
+  }
+}
 
 /**
  * Creates an rpc request
@@ -102,4 +129,14 @@ export function isRPCCallbackCall (payload: any): payload is RPCCallbackCall {
 
 export function isRPCCallbackPlaceholder (payload: any): payload is RPCCallbackPlaceholderParam {
   return payload?._transframeCallback === true;
+}
+
+export function isRPCConnectRequest (payload: any): payload is RPCConnectRequest {
+  return isRPCMessage(payload) &&
+    payload.type === RPCMessageType.RPC_CONNECT_REQUEST;
+}
+
+export function isRPCConnectResponse (payload: any): payload is RPCConnectResponse {
+  return isRPCMessage(payload) &&
+    payload.type === RPCMessageType.RPC_CONNECT_RESPONSE;
 }

--- a/npm/transframe/src/transframe-consumer.ts
+++ b/npm/transframe/src/transframe-consumer.ts
@@ -75,7 +75,6 @@ export class TransframeConsumer<SourceApi extends TransframeSourceApi<ContextFro
   }
 
   public connect = async () => {
-    console.log('connect called')
     // if we're already connecting or connected, don't do anything
     if (this._isConnecting || this._isConnected) return;
 
@@ -103,19 +102,16 @@ export class TransframeConsumer<SourceApi extends TransframeSourceApi<ContextFro
       }
 
       // send the connect request
-      console.log('sending connect request');
       sendConnectRequest();
       // try more times in case the provider missed the first requests
       const timer = setInterval(() => {
         // if we're connected, stop trying
         if (this._isConnected) {
-          console.log('connected! stopping timer')
           clearInterval(timer);
         }
 
         // if we haven't gotten a response yet, try again
         else if (retryCount < CONNECT_RETRY_COUNT) {
-          console.log('retrying connect request');
           sendConnectRequest();
         }
 
@@ -131,7 +127,6 @@ export class TransframeConsumer<SourceApi extends TransframeSourceApi<ContextFro
       }, CONNECT_RETRY_INTERVAL);
     });
 
-    console.log('available methods', availableMethods)
     // make sure the available methods set is cleared
     this._availableMethods.clear();
     // set the available methods
@@ -206,7 +201,6 @@ export class TransframeConsumer<SourceApi extends TransframeSourceApi<ContextFro
     if (!this._isConnected && !this._isConnecting) {
       throw new Error('Cannot call any api methods: Not connected to provider');
     } else if (this._isConnecting) {
-      console.log('connecting, queueing call', method);
       // if we're connecting, queue up the call and await a promise that will resolve when the connection is complete
       await new Promise((resolve) => {
         this._apiCallQueue.push(resolve);

--- a/npm/transframe/src/transframe-consumer.ts
+++ b/npm/transframe/src/transframe-consumer.ts
@@ -215,7 +215,7 @@ export class TransframeConsumer<SourceApi extends TransframeSourceApi<ContextFro
     const methodString = String(method);
 
     // if the method is not available, throw an error
-    if (!this._availableMethods.has(methodString)) {
+    if (!this.hasMethod(methodString)) {
       throw new Error(`Method ${methodString} is not available`);
     }
 

--- a/npm/transframe/src/transframe-consumer.ts
+++ b/npm/transframe/src/transframe-consumer.ts
@@ -74,6 +74,10 @@ export class TransframeConsumer<SourceApi extends TransframeSourceApi<ContextFro
     return this._isConnected && this._interface.isConnected;
   }
 
+  public hasMethod(method: string) {
+    return this._availableMethods.has(method);
+  }
+
   public connect = async () => {
     // if we're already connecting or connected, don't do anything
     if (this._isConnecting || this._isConnected) return;


### PR DESCRIPTION
This PR implements an rpc handshake sequence that operates when a consumer is first establishing a connection with the provider.

The consumer will first send a request to connect to the provider. The consumer will send 5 of these 5 ms apart in case the provider misses the first requests (which could happen if the provider hasn't initialized yet). The provider will respond with a list of available methods in its api. The consumer will then save the list of methods for future reference. Since the consumer has a list of available methods, it will immediately be able to tell if a non-existent method is being called without having to contact the provider.

During the handshake sequence, it's possible that the user tries to make api calls. To make sure these get processed after the connection is established, we put the api calls in a queue and process them after the connection to the provider has been established. 